### PR TITLE
ownCloud version bump 7.0.2 -> 7.0.4

### DIFF
--- a/owncloud/manifest.json
+++ b/owncloud/manifest.json
@@ -17,7 +17,7 @@
             "secondary": ["Documents", "Music", "Photos", "Calendar", "Contacts"]
         }
     ],
-    "version": "7.0.2-2",
+    "version": "7.0.4",
     "author": "arkOS",
     "homepage": "http://arkos.io",
     "app_author": "ownCloud",
@@ -97,7 +97,7 @@
     "generation": 1,
     "website_plugin": "ownCloud",
     "website_updates": false,
-    "download_url": "https://download.owncloud.org/community/owncloud-7.0.2.tar.bz2",
+    "download_url": "https://download.owncloud.org/community/owncloud-7.0.4.tar.bz2",
     "database_engines": ["MariaDB"],
     "uses_php": true,
     "uses_ssl": true


### PR DESCRIPTION
Updated version and source URL for ownCloud 7.04 (was at 7.0.2). This was just two minor security / bugfix releases with no major features / api changes, and I've already tried upgrading via the recommended method of copying the files over the oldf install (on my arkOS box) without any issues.

Not sure if anything needs to be done to inform servers of the new version beyond editing this manifest file. If so, please let me know, so I can do it next time.
