### PR TITLE
Version bump to Beta 2

### DIFF
--- a/mailpile/manifest.json
+++ b/mailpile/manifest.json
@@ -1,6 +1,6 @@
 {
     "id": "mailpile",
-    "name": "Mailpile BETA",
+    "name": "Mailpile BETA 2",
     "type": "website",
     "icon": "fa fa-envelope",
     "description": {
@@ -13,7 +13,7 @@
             "secondary": ["Email"]
         }
     ],
-    "version": "0.4.1-1",
+    "version": "0.4.2-1",
     "author": "arkOS",
     "homepage": "https://arkos.io",
     "app_author": "Mailpile",
@@ -50,7 +50,7 @@
     ],
     "generation": 1,
     "website_updates": false,
-    "download_url": "https://github.com/mailpile/Mailpile/archive/0.4.1.tar.gz",
+    "download_url": "https://github.com/mailpile/Mailpile/archive/0.4.2.tar.gz",
     "database_engines": [],
     "uses_php": false,
     "uses_ssl": true


### PR DESCRIPTION
Update manifest.json to upgrade version to the Beta 2 release of Mailpile.
